### PR TITLE
Fix ambiguity problems in sum_structs

### DIFF
--- a/src/SumStructs.jl
+++ b/src/SumStructs.jl
@@ -47,6 +47,7 @@ function _sum_structs(type, struct_defs)
     isnotmutable = all(!(d.args[1]) for d in struct_defs)
     
     variants_types = []
+    variants_types_constrained = []
     hidden_struct_types = []
     variants_params_unconstr = [[] for _ in 1:length(struct_defs)]
 
@@ -64,6 +65,7 @@ function _sum_structs(type, struct_defs)
         append!(variants_params_unconstr[i], t_p)
         t_p_no_sup = [p isa Expr && p.head == :(<:) ? p.args[1] : p for p in t_p]
         push!(variants_types, t_p != [] ? :($t_n{$(t_p_no_sup...)}) : t_n)
+        push!(variants_types_constrained, t_p != [] ? :($t_n{$(t_p...)}) : t_n)
         h_t = gensym(t_n)
         if t_p_no_sup != []
             h_t = :($h_t{$(t_p_no_sup...)})
@@ -79,7 +81,7 @@ function _sum_structs(type, struct_defs)
 
     struct_defs = [:($Base.@kwdef $d) for d in struct_defs]
 
-    variants_defs = [:($t(ht::$ht)) for (t, ht) in zip(variants_types, hidden_struct_types)]
+    variants_defs = [:($t(ht::$ht)) for (t, ht) in zip(variants_types_constrained, hidden_struct_types)]
 
     abstract_t = type isa Expr && type.head == :(<:) ? type.args[2] : :(Any)
     type_no_abstract = type isa Expr && type.head == :(<:) ? type.args[1] : type


### PR DESCRIPTION
So that this

```julia
using StaticArrays
using MixedStructTypes

const Point3 = SVector{3}
const Vector3 = SVector{3}

abstract type AbstractShape{T<:AbstractFloat} end

@sum_structs Shape{T<:AbstractFloat, SL, SR} <: AbstractShape{T} begin
	struct Box{T<:AbstractFloat}
	    fDimensions::Vector3{T}
	end
	struct Tube{T<:AbstractFloat}
	    rmin::T
	    rmax::T
	    z::T
	end
	struct Cone{T<:AbstractFloat}
	    r::T
	    z::T
	end
	struct BooleanUnion{T<:AbstractFloat, SL<:AbstractShape{T}, SR<:AbstractShape{T}}
	    left::SL 
	    right::SR
	end
end

box1 = Box{Float64}((1,2,3))
```

would work. Now we have:

```julia
ERROR: MethodError: Box{Float64}(::var"##Box#225"{Float64}) is ambiguous.

Candidates:
  Box{T}(fDimensions) where T<:AbstractFloat
    @ Main ~/.julia/dev/MixedStructTypes/src/SumStructs.jl:222
  Box{T}(ht::var"##Box#225"{T}) where T
    @ Main ~/.julia/dev/SumTypes/src/sum_type.jl:179

Possible fix, define
  Box{T}(::var"##Box#225"{T}) where T<:AbstractFloat

Stacktrace:
 [1] Box{Float64}(fDimensions::Tuple{Int64, Int64, Int64})
   @ Main ~/.julia/dev/MixedStructTypes/src/SumStructs.jl:224
 [2] top-level scope
   @ REPL[7]:1

```

...after https://github.com/MasonProtter/SumTypes.jl/pull/78